### PR TITLE
Tests

### DIFF
--- a/memsafe-checker/Cargo.toml
+++ b/memsafe-checker/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+assert_cmd = "2.0.12"
 clap = { version = "4.4.6", features = ["derive"] }
 env_logger = "0.10.0"
 log = "0.4.20"
+predicates = "3.0.4"

--- a/memsafe-checker/src/main.rs
+++ b/memsafe-checker/src/main.rs
@@ -960,8 +960,8 @@ impl ARMCORTEXA {
 struct Args {
     file: PathBuf,
     label: String,
-    context: Option<String>,
     input: Option<String>,
+    context: Option<String>,
     length_reg: Option<String>,
     length_value: Option<u64>,
 }

--- a/memsafe-checker/src/main.rs
+++ b/memsafe-checker/src/main.rs
@@ -960,10 +960,10 @@ impl ARMCORTEXA {
 struct Args {
     file: PathBuf,
     label: String,
-    context: String,
-    input: String,
-    length: String,
-    length_value: usize,
+    context: Option<String>,
+    input: Option<String>,
+    length_reg: Option<String>,
+    length_value: Option<u64>,
 }
 
 fn main() -> std::io::Result<()> {
@@ -1042,9 +1042,17 @@ fn main() -> std::io::Result<()> {
     let mut computer = ARMCORTEXA::new();
 
     // this is the context, i.e. A,B,C,D,E for the function
-    computer.set_context(args.context);
-    computer.set_input(args.input);
-    computer.set_length(args.length, args.length_value.try_into().unwrap());
+    // FIX: when is context different than input? read but not write? not relevant for sha-256.
+    if let Some(context) = args.context {
+        computer.set_context(context);
+    }
+    if let Some(input) = args.input {
+        computer.set_input(input);
+    }
+    if let Some(length_reg) = args.length_reg {
+        computer.set_length(length_reg, args.length_value.unwrap());
+    }
+    
 
     //let mut alignment = 4;
     let mut address = 0;

--- a/memsafe-checker/tests/asm-examples/stack_misalign.S
+++ b/memsafe-checker/tests/asm-examples/stack_misalign.S
@@ -2,6 +2,5 @@ stack_test:
     add x3,x3,#21
 	str x3,sp,#14
 	str x3,[sp,#14]
-	sub sp,sp,#14
-	ldr x4,sp
+	ldr x4,[sp,#10]
     ret

--- a/memsafe-checker/tests/cli.rs
+++ b/memsafe-checker/tests/cli.rs
@@ -1,0 +1,14 @@
+use assert_cmd::prelude::*; // Add methods on commands
+use predicates::prelude::*; // Used for writing assertions
+use std::process::Command; // Run programs
+
+#[test]
+fn test_stack() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("memsafe-checker")?;
+
+    cmd.arg("./tests/asm-examples/stack_push_pop.S").arg("test_stack");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Symbolic execution done"));
+    Ok(())
+}

--- a/memsafe-checker/tests/cli.rs
+++ b/memsafe-checker/tests/cli.rs
@@ -3,12 +3,22 @@ use predicates::prelude::*; // Used for writing assertions
 use std::process::Command; // Run programs
 
 #[test]
-fn test_stack() -> Result<(), Box<dyn std::error::Error>> {
+fn stack_is_ok() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("memsafe-checker")?;
 
     cmd.arg("./tests/asm-examples/stack_push_pop.S").arg("test_stack");
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("Symbolic execution done"));
+    Ok(())
+}
+
+#[test]
+fn bad_stack_read_is_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("memsafe-checker")?;
+
+    cmd.arg("./tests/asm-examples/stack_misalign.S").arg("stack_test");
+    cmd.assert()
+        .stderr(predicate::str::contains("MemorySafetyError"));
     Ok(())
 }


### PR DESCRIPTION
- Make cmd line options more flexible
- Positive tests
   - Stack builds correctly
   - Memory modeled correctly
   - Loops and branches jump/terminate correctly
 - Negative tests (return memory safety error)
   - can't read/write from immediate address
   - can't read/write from input as address
   - can't pointer chase
   - can't read between stack entries
   - can't write program memory
   - can't jump to unavailable labels