### PR TITLE
Memory safe sha256 and ghash e2e prototype

### DIFF
--- a/bums_macros/src/lib.rs
+++ b/bums_macros/src/lib.rs
@@ -7,12 +7,12 @@ use punctuated::Punctuated;
 use quote::quote;
 use std::collections::HashMap;
 use std::fs::File;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::{BufRead, BufReader};
 use syn::*;
 use z3::{Config, Context};
 
-use bums;
-use bums::common::{AbstractExpression, RegionType};
+use bums::common::*;
 
 #[derive(Debug)]
 struct CallColon {
@@ -104,6 +104,12 @@ fn calculate_type_of_slice_ptr(a: &TypeSlice) -> String {
     return elem;
 }
 
+fn calculate_hash<T: Hash>(t: &T) -> u64 {
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish()
+}
+
 // ATTRIBUTE ON EXTERN BLOCK
 #[proc_macro_attribute]
 #[proc_macro_error]
@@ -118,6 +124,7 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input_sizes = HashMap::new();
     let mut pointer_sizes = HashMap::new();
     let mut input_types = HashMap::new();
+    let mut input_expressions = HashMap::new();
     let mut arguments_to_pass: Punctuated<_, _> = Punctuated::new();
     // if caller did not specify arguments in macro, grab names from function call
     if attributes.argument_list.is_empty() {
@@ -179,12 +186,12 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 let ty = calculate_type_of_slice_ptr(b);
                                 pointer_sizes.insert(name, ty);
                             }
-                            _ => (),
+                            _ => todo!(),
                         },
-                        _ => (),
+                        _ => todo!(),
                     }
                 }
-                _ => (),
+                _ => todo!(),
             }
         }
         for i in &attributes.argument_list {
@@ -255,7 +262,7 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     "u8" => new_args.push(parse_quote! {#n: *mut u8}),
                                     "u32" => new_args.push(parse_quote! {#n: *mut u32}),
                                     "u64" => new_args.push(parse_quote! {#n: *mut u64}),
-                                    "u128" => new_args.push(parse_quote! {#n: *const u128}),
+                                    "u128" => new_args.push(parse_quote! {#n: *mut u128}),
                                     _ => (),
                                 }
                             } else {
@@ -275,13 +282,14 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
                         new_args.push(parse_quote! {#i: #ty});
                     }
                 }
-                Expr::Binary(_) => {
-                    //FIX: find a better name for this
-                    let n = Ident::new("expr", proc_macro2::Span::call_site().into());
-                    new_args.push(parse_quote! {#n : usize});
+                Expr::Binary(b) => {
+                    let exp = quote!{#b}.to_string();
+                    let name = "expr_".to_owned() + &calculate_hash(&exp).to_string();
+                    input_expressions.insert(name.clone(), exp);
+                    new_args.push(parse_quote! {#name : usize});
                 }
-                Expr::Lit(_) => new_args.push(parse_quote! {_: usize}),
-                _ => (),
+                Expr::Lit(l) => new_args.push(parse_quote! {#l: usize}),
+                _ => todo!(),
             }
         }
         for a in &new_args {
@@ -342,7 +350,13 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
                     Pat::Ident(b) => {
                         name = b.ident.clone().to_string();
                     }
-                    _ => (),
+                    Pat::Lit(l) => {
+                        match &l.lit {
+                            Lit::Str(s) =>name =  s.value(),
+                            _ => todo!(),
+                        }
+                    }
+                    _ => todo!(),
                 }
                 //get type to get size
                 match &*pat_type.ty {
@@ -351,21 +365,21 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
                         // for c in &a.path.segments {
                         //      size = size + calculate_size_of(c.ident.to_string());
                         // }
-                        engine.add_abstract_from(i, name.clone());
+                        if let Some(binary) = input_expressions.get(&name) {
+                            engine.add_abstract_expression_from(i, string_to_expression(binary));
+                        } else {
+                            engine.add_abstract_from(i, name.clone());
+                        }
                     }
                     Type::Array(a) => {
                         let size = calculate_size_of_array(a);
                         engine.add_abstract_from(i, name.clone());
                         engine.add_region(
-                            RegionType::WRITE,
+                            RegionType::RW,
                             name.clone(),
                             AbstractExpression::Immediate(size as i64),
                         );
-                        engine.add_region(
-                            RegionType::READ,
-                            name.clone(),
-                            AbstractExpression::Immediate(size as i64),
-                        );
+
                     }
                     Type::Ptr(a) => {
                         // load pointer into register
@@ -377,32 +391,34 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                         // if pointing to an array defined as a function param, no abstract length
                         if let Some(bound) = input_sizes.get(no_suffix) {
-                            engine.add_region(
-                                RegionType::READ,
-                                name.clone(),
-                                AbstractExpression::Immediate(bound.clone() as i64),
-                            );
                             if a.mutability.is_some() {
                                 engine.add_region(
-                                    RegionType::WRITE,
+                                    RegionType::RW,
                                     name.clone(),
                                     AbstractExpression::Immediate(*bound as i64),
+                                );
+                            } else {
+                                engine.add_region(
+                                    RegionType::READ,
+                                    name.clone(),
+                                    AbstractExpression::Immediate(bound.clone() as i64),
                                 );
                             }
                             continue;
                         }
 
                         let bound = no_suffix.to_owned() + "_len";
-                        engine.add_region(
-                            RegionType::READ,
-                            name.clone(),
-                            AbstractExpression::Abstract(bound.clone()),
-                        );
-                        if a.mutability.is_some() {
+                        if a.mutability.is_some() {  
                             engine.add_region(
                                 RegionType::WRITE,
                                 name.clone(),
                                 AbstractExpression::Abstract(bound),
+                            );
+                        } else {
+                            engine.add_region(
+                                RegionType::READ,
+                                name.clone(),
+                                AbstractExpression::Abstract(bound.clone()),
                             );
                         }
                     }

--- a/bums_macros/src/lib.rs
+++ b/bums_macros/src/lib.rs
@@ -110,6 +110,60 @@ fn calculate_hash<T: Hash>(t: &T) -> u64 {
     s.finish()
 }
 
+fn binary_to_abstract_expression(input: &ExprBinary) -> AbstractExpression {
+    let left_expr = syn_expr_to_abstract_expression(&input.left);
+    let right_expr = syn_expr_to_abstract_expression(&input.right);
+
+    match input.op {
+        BinOp::Add(_) => return generate_expression("+", left_expr, right_expr),
+        BinOp::Sub(_) => return generate_expression("-", left_expr, right_expr),
+        BinOp::Div(_) => return generate_expression("/", left_expr, right_expr),
+        BinOp::Mul(_) => return generate_expression("*", left_expr, right_expr),
+        _ => todo!(),
+    }
+}
+
+fn syn_expr_to_abstract_expression(input: &Expr) -> AbstractExpression {
+    match &input {
+        Expr::Lit(l) => match &l.lit {
+            Lit::Str(s) => return AbstractExpression::Abstract(s.value()),
+            Lit::Int(i) => {
+                return AbstractExpression::Immediate(
+                    i.base10_parse::<i64>().expect("undefined integer"),
+                )
+            }
+            _ => todo!(),
+        },
+        Expr::Binary(b) => return binary_to_abstract_expression(b),
+        Expr::MethodCall(c) => {
+            let mut var_name: String = String::new();
+            match *c.receiver.clone() {
+                Expr::Path(a) => {
+                    var_name = a.path.segments[0].ident.to_string();
+                }
+                _ => (),
+            }
+            match c.method.to_string().as_str() {
+                "len" => {
+                    var_name = var_name + "_len";
+                }
+                "as_ptr" => {
+                    var_name = var_name + "_as_ptr";
+                }
+                "as_mut_ptr" => {
+                    var_name = var_name + "_as_mut_ptr";
+                }
+                _ => (),
+            };
+            return AbstractExpression::Abstract(var_name);
+        }
+        Expr::Path(p) => {
+            return AbstractExpression::Abstract(p.path.segments[0].ident.to_string());
+        }
+        _ => todo!(),
+    }
+}
+
 // ATTRIBUTE ON EXTERN BLOCK
 #[proc_macro_attribute]
 #[proc_macro_error]
@@ -224,11 +278,11 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
     extern_fn.ident = fn_name.clone();
     if !attributes.argument_list.is_empty() {
         let mut new_args: Punctuated<FnArg, Token![,]> = Punctuated::new();
+        let mut span = proc_macro2::Span::call_site();
         for i in attributes.argument_list {
             match i {
                 Expr::MethodCall(a) => {
                     let mut var_name: String = String::new();
-                    let mut span = proc_macro2::Span::call_site();
                     match *a.receiver {
                         Expr::Path(a) => {
                             var_name = a.path.segments[0].ident.to_string();
@@ -283,10 +337,11 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
                     }
                 }
                 Expr::Binary(b) => {
-                    let exp = quote!{#b}.to_string();
+                    let exp = quote! {#b}.to_string();
                     let name = "expr_".to_owned() + &calculate_hash(&exp).to_string();
-                    input_expressions.insert(name.clone(), exp);
-                    new_args.push(parse_quote! {#name : usize});
+                    input_expressions.insert(name.clone(), b);
+                    let n = Ident::new(&name, span.into());
+                    new_args.push(parse_quote! {#n : usize});
                 }
                 Expr::Lit(l) => new_args.push(parse_quote! {#l: usize}),
                 _ => todo!(),
@@ -350,23 +405,20 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
                     Pat::Ident(b) => {
                         name = b.ident.clone().to_string();
                     }
-                    Pat::Lit(l) => {
-                        match &l.lit {
-                            Lit::Str(s) =>name =  s.value(),
-                            _ => todo!(),
-                        }
-                    }
+                    Pat::Lit(l) => match &l.lit {
+                        Lit::Str(s) => name = s.value(),
+                        _ => todo!(),
+                    },
                     _ => todo!(),
                 }
                 //get type to get size
                 match &*pat_type.ty {
                     Type::Path(_) => {
-                        // simple types that fit in a register?
-                        // for c in &a.path.segments {
-                        //      size = size + calculate_size_of(c.ident.to_string());
-                        // }
                         if let Some(binary) = input_expressions.get(&name) {
-                            engine.add_abstract_expression_from(i, string_to_expression(binary));
+                            engine.add_abstract_expression_from(
+                                i,
+                                binary_to_abstract_expression(binary),
+                            );
                         } else {
                             engine.add_abstract_from(i, name.clone());
                         }
@@ -379,7 +431,6 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
                             name.clone(),
                             AbstractExpression::Immediate(size as i64),
                         );
-
                     }
                     Type::Ptr(a) => {
                         // load pointer into register
@@ -408,17 +459,25 @@ pub fn check_mem_safe(attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
 
                         let bound = no_suffix.to_owned() + "_len";
-                        if a.mutability.is_some() {  
+                        if a.mutability.is_some() {
                             engine.add_region(
                                 RegionType::WRITE,
                                 name.clone(),
-                                AbstractExpression::Abstract(bound),
+                                generate_expression(
+                                    "*",
+                                    AbstractExpression::Abstract(bound),
+                                    AbstractExpression::Immediate(8),
+                                ),
                             );
                         } else {
                             engine.add_region(
                                 RegionType::READ,
                                 name.clone(),
-                                AbstractExpression::Abstract(bound.clone()),
+                                generate_expression(
+                                    "*",
+                                    AbstractExpression::Abstract(bound),
+                                    AbstractExpression::Immediate(8),
+                                ),
                             );
                         }
                     }

--- a/crypto-playground/assembly/aws-fips/wrapped-ghash-neon-armv8.S
+++ b/crypto-playground/assembly/aws-fips/wrapped-ghash-neon-armv8.S
@@ -60,6 +60,9 @@ _gcm_gmult_neon:
 .align	4
 _gcm_ghash_neon:
 	// AARCH64_VALID_CALL_TARGET
+	cmp x3, xzr
+	b.eq Early_abort
+
 	ld1	{v0.16b}, [x0]		// load Xi
 	ld1	{v5.1d}, [x1], #8		// load twisted H
 	ld1	{v6.1d}, [x1]
@@ -321,6 +324,8 @@ Lgmult_neon:
 
 	ret
 
+Early_abort:
+	ret
 
 .section	__TEXT,__const
 .align	4

--- a/crypto-playground/assembly/aws-fips/wrapped-sha256-armv8.S
+++ b/crypto-playground/assembly/aws-fips/wrapped-sha256-armv8.S
@@ -55,6 +55,10 @@
 _sha256_block_data_order:
 	// AARCH64_VALID_CALL_TARGET
 	// AARCH64_SIGN_LINK_REGISTER
+
+	cmp x2, xzr
+	b.eq Early_abort
+
 	stp	x29,x30,[sp,#-128]!
 	add	x29,sp,#0
 
@@ -1018,6 +1022,8 @@ Loop_16_xx:
 	// AARCH64_VALIDATE_LINK_REGISTER
 	ret
 
+Early_abort:
+	ret
 
 .section	__TEXT,__const
 .align	6

--- a/crypto-playground/src/gcm.rs
+++ b/crypto-playground/src/gcm.rs
@@ -1,10 +1,10 @@
-#[bums_macros::check_mem_safe("assembly/aws-fips/ghash-neon-armv8.S", htable.as_mut_ptr(), h.as_ptr())]
+#[bums_macros::check_mem_safe("assembly/aws-fips/wrapped-ghash-neon-armv8.S", htable.as_mut_ptr(), h.as_ptr())]
 fn gcm_init_neon(htable: &mut [u128; 16], h: &[u64; 2]);
 
-#[bums_macros::check_mem_safe("assembly/aws-fips/ghash-neon-armv8.S", context.as_mut_ptr(), h.as_ptr())]
+#[bums_macros::check_mem_safe("assembly/aws-fips/wrapped-ghash-neon-armv8.S", context.as_mut_ptr(), h.as_ptr())]
 fn gcm_gmult_neon(context: &mut [u8; 16], h: &[u64; 2]);
 
-#[bums_macros::check_mem_safe("assembly/aws-fips/ghash-neon-armv8.S", context.as_mut_ptr(), h.as_ptr(), buf.as_ptr(), buf.len() / 16)]
+#[bums_macros::check_mem_safe("assembly/aws-fips/wrapped-ghash-neon-armv8.S", context.as_mut_ptr(), h.as_ptr(), buf.as_ptr(), buf.len() / 16)]
 fn gcm_ghash_neon(context: &mut [u8; 16], h: &[u128; 16], buf: &[u8]);
 
 #[cfg(test)]

--- a/crypto-playground/src/gcm.rs
+++ b/crypto-playground/src/gcm.rs
@@ -4,7 +4,7 @@ fn gcm_init_neon(htable: &mut [u128; 16], h: &[u64; 2]);
 #[bums_macros::check_mem_safe("assembly/aws-fips/ghash-neon-armv8.S", context.as_mut_ptr(), h.as_ptr())]
 fn gcm_gmult_neon(context: &mut [u8; 16], h: &[u64; 2]);
 
-#[bums_macros::check_mem_safe("assembly/aws-fips/ghash-neon-armv8.S", context.as_mut_ptr(), h.as_ptr(), buf.as_ptr(), buf.len() )]
+#[bums_macros::check_mem_safe("assembly/aws-fips/ghash-neon-armv8.S", context.as_mut_ptr(), h.as_ptr(), buf.as_ptr(), buf.len() / 16)]
 fn gcm_ghash_neon(context: &mut [u8; 16], h: &[u128; 16], buf: &[u8]);
 
 #[cfg(test)]

--- a/crypto-playground/src/lib.rs
+++ b/crypto-playground/src/lib.rs
@@ -3,3 +3,9 @@ pub mod bn;
 pub mod gcm;
 pub mod sha256;
 mod utils;
+
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+// TODO(alevy): This should be computed as in AWS-LC's 'crypto/fipsmodule/cpucap'
+// Setting to 0 assumes no special crypto instructions (NEON, AES, PMULL, SHA1, SHA256, SHA512, SHA3, CPUID)
+#[no_mangle]
+pub static OPENSSL_armcap_P: usize = 0;

--- a/crypto-playground/src/sha256.rs
+++ b/crypto-playground/src/sha256.rs
@@ -124,7 +124,7 @@ pub fn sha256_digest(msg: &[u8], output: &mut [u8]) {
     sha256(msg, msg.len(), output);
 }
 
-#[bums_macros::check_mem_safe("assembly/aws-fips/sha256-armv8.S", context.as_mut_ptr(), input.as_ptr(), input.len() / SHA256_CBLOCK)]
+#[bums_macros::check_mem_safe("assembly/aws-fips/sha256-armv8.S", context.as_mut_ptr(), input.as_ptr(), input.len() / 64)]
 fn sha256_block_data_order(context: &mut [u32; 8], input: &[u8]);
 
 #[cfg(test)]

--- a/crypto-playground/src/sha256.rs
+++ b/crypto-playground/src/sha256.rs
@@ -124,7 +124,7 @@ pub fn sha256_digest(msg: &[u8], output: &mut [u8]) {
     sha256(msg, msg.len(), output);
 }
 
-#[bums_macros::check_mem_safe("assembly/aws-fips/sha256-armv8.S", context.as_mut_ptr(), input.as_ptr(), input.len() / 64)]
+#[bums_macros::check_mem_safe("assembly/aws-fips/wrapped-sha256-armv8.S", context.as_mut_ptr(), input.as_ptr(), input.len() / 64)]
 fn sha256_block_data_order(context: &mut [u32; 8], input: &[u8]);
 
 #[cfg(test)]

--- a/memsafe-checker/src/common.rs
+++ b/memsafe-checker/src/common.rs
@@ -763,3 +763,7 @@ pub fn comparison_to_ast(context: &Context, expression: AbstractComparison) -> O
         _ => todo!(),
     }
 }
+
+pub fn string_to_expression(input: &String) -> AbstractExpression {
+    todo!()
+}

--- a/memsafe-checker/src/common.rs
+++ b/memsafe-checker/src/common.rs
@@ -48,16 +48,16 @@ pub struct SimdRegister {
 pub const BASE_INIT: Option<AbstractExpression> = None;
 
 impl SimdRegister {
-    pub fn new(name: &str) -> Self {
-        let string_name = name.to_string();
-        let mut bases = [BASE_INIT; 16];
-        for i in 0..16 {
-            bases[i] = Some(AbstractExpression::Abstract(
-                string_name.clone() + "_" + &i.to_string(),
-            ));
-        }
+    pub fn new(_name: &str) -> Self {
+        // let string_name = name.to_string();
+        let bases = [BASE_INIT; 16];
+        // for i in 0..16 {
+        //     bases[i] = Some(AbstractExpression::Abstract(
+        //         string_name.clone() + "_" + &i.to_string(),
+        //     ));
+        // }
         Self {
-            kind: RegisterKind::RegisterBase,
+            kind: RegisterKind::Number,
             base: bases,
             offset: [0; 16],
         }
@@ -706,9 +706,13 @@ pub fn expression_to_ast(context: &Context, expression: AbstractExpression) -> O
             return Some(ast::Int::new_const(context, a));
         }
         AbstractExpression::Register(reg) => {
-            let base = expression_to_ast(context, reg.base.clone().unwrap()).unwrap();
-            let offset = ast::Int::from_i64(context, reg.offset);
-            return Some(ast::Int::add(context, &[&base, &offset]));
+            if let Some(base) = reg.base.clone() {
+                let base = expression_to_ast(context, base).unwrap();
+                let offset = ast::Int::from_i64(context, reg.offset);
+                return Some(ast::Int::add(context, &[&base, &offset]));
+            } else {
+                return Some(ast::Int::from_i64(context, reg.offset));
+            }
         }
         AbstractExpression::Expression(op, old1, old2) => {
             let new1 = expression_to_ast(context, *old1).unwrap();

--- a/memsafe-checker/src/common.rs
+++ b/memsafe-checker/src/common.rs
@@ -468,7 +468,6 @@ impl MemorySafeRegion {
             }
             _ => (),
         }
-
         Self {
             kind,
             length,
@@ -762,8 +761,4 @@ pub fn comparison_to_ast(context: &Context, expression: AbstractComparison) -> O
         }
         _ => todo!(),
     }
-}
-
-pub fn string_to_expression(input: &String) -> AbstractExpression {
-    todo!()
 }

--- a/memsafe-checker/src/computer.rs
+++ b/memsafe-checker/src/computer.rs
@@ -2101,7 +2101,10 @@ impl<'ctx> ARMCORTEXA<'_> {
         };
 
         if ty == RegionType::WRITE && region.kind == RegionType::READ {
-            return Err(MemorySafetyError::new(&format!("Access does not match region type {:#?} {:?} {:?}", region.kind, ty, base_expr)));
+            return Err(MemorySafetyError::new(&format!(
+                "Access does not match region type {:#?} {:?} {:?}",
+                region.kind, ty, base_expr
+            )));
         }
 
         let mut abs_offset = ast::Int::from_i64(self.context, offset);

--- a/memsafe-checker/src/computer.rs
+++ b/memsafe-checker/src/computer.rs
@@ -37,7 +37,7 @@ fn get_register_index(reg_name: String) -> usize {
 pub struct ARMCORTEXA<'ctx> {
     pub registers: [RegisterValue; 33],
     pub simd_registers: [SimdRegister; 32],
-    zero: Option<FlagValue>,
+    pub zero: Option<FlagValue>,
     neg: Option<FlagValue>,
     carry: Option<FlagValue>,
     overflow: Option<FlagValue>,
@@ -167,7 +167,7 @@ impl<'ctx> ARMCORTEXA<'_> {
         &self,
     ) -> (
         [RegisterValue; 33],
-        [SimdRegister; 32],
+        // [SimdRegister; 32],
         Option<FlagValue>,
         Option<FlagValue>,
         Option<FlagValue>,
@@ -175,7 +175,7 @@ impl<'ctx> ARMCORTEXA<'_> {
     ) {
         return (
             self.registers.clone(),
-            self.simd_registers.clone(),
+            // self.simd_registers.clone(),
             self.zero.clone(),
             self.neg.clone(),
             self.carry.clone(),
@@ -349,8 +349,8 @@ impl<'ctx> ARMCORTEXA<'_> {
                 }
                 "subs" => {
                     self.cmp(
-                        instruction.r1.clone().expect("need register to compare"),
                         instruction.r2.clone().expect("need register to compare"),
+                        instruction.r3.clone().expect("need register to compare"),
                     );
 
                     self.arithmetic(
@@ -623,24 +623,24 @@ impl<'ctx> ARMCORTEXA<'_> {
                 }
                 "b.ne" | "bne" => {
                     match &self.zero {
-                // if zero is set to false, then cmp -> not equal and we branch
-                Some(flag) => match flag {
-                    FlagValue::REAL(b) => {
-                        if !b {
-                            return Ok(Some((None, instruction.r1.clone(), None)));
-                        } else {
-                            return Ok(None);
-                        }
+                                // if zero is set to false, then cmp -> not equal and we branch
+                        Some(flag) => match flag {
+                            FlagValue::REAL(b) => {
+                                if !b {
+                                    return Ok(Some((None, instruction.r1.clone(), None)));
+                                } else {
+                                    return Ok(None);
+                                }
+                            }
+                            FlagValue::ABSTRACT(s) => {
+                                return Ok(Some((Some(s.clone()), instruction.r1.clone(), None)));
+                            }
+                        },
+                        None => return Err(
+                            "Flag cannot be branched on since it has not been set within the program yet"
+                                .to_string(),
+                        ),
                     }
-                    FlagValue::ABSTRACT(s) => {
-                        return Ok(Some((Some(s.clone()), instruction.r1.clone(), None)));
-                    }
-                },
-                None => return Err(
-                    "Flag cannot be branched on since it has not been set within the program yet"
-                        .to_string(),
-                ),
-            }
                 }
                 "b.eq" => {
                     match &self.zero {
@@ -674,7 +674,7 @@ impl<'ctx> ARMCORTEXA<'_> {
                             }
                             return Ok(Some((None, None, Some(x30.offset.try_into().unwrap()))));
                         } else {
-                            log::error!("cannot jump on non-address");
+                            return Ok(Some((None, Some("return".to_string()), None)));
                         }
                     } else {
                         let _r1 = &self.registers[get_register_index(
@@ -1630,8 +1630,8 @@ impl<'ctx> ARMCORTEXA<'_> {
     }
 
     fn cmp(&mut self, reg1: String, reg2: String) {
-        let r1 = self.registers[get_register_index(reg1.clone())].clone();
-        let r2 = self.registers[get_register_index(reg2.clone())].clone();
+        let r1 = self.operand(reg1.clone()).clone();
+        let r2 = self.operand(reg2.clone()).clone();
 
         if r1.kind == r2.kind {
             match r1.kind {
@@ -2104,7 +2104,10 @@ impl<'ctx> ARMCORTEXA<'_> {
             return Err(MemorySafetyError::new("Access does not match region type"));
         }
 
-        let abs_offset = ast::Int::from_i64(self.context, offset);
+        let mut abs_offset = ast::Int::from_i64(self.context, offset);
+        if base_expr.contains("sp") {
+            abs_offset = ast::Int::from_i64(self.context, offset.abs());
+        }
         let access = ast::Int::add(self.context, &[&base, &abs_offset]);
 
         // let width = ast::Int::from_i64(self.context, 2);    // how wide is memory access, two bytes
@@ -2125,6 +2128,7 @@ impl<'ctx> ARMCORTEXA<'_> {
                 return Ok(());
             }
             (a, b) => {
+                log::info!("Load from address {:?} + {} unsafe", base_expr, offset);
                 log::error!(
                     "impossibility lower bound {:?}, impossibility upper bound {:?}, model: {:?}",
                     a,

--- a/memsafe-checker/src/computer.rs
+++ b/memsafe-checker/src/computer.rs
@@ -2100,8 +2100,8 @@ impl<'ctx> ARMCORTEXA<'_> {
             }
         };
 
-        if region.kind != ty && region.kind != RegionType::RW {
-            return Err(MemorySafetyError::new("Access does not match region type"));
+        if ty == RegionType::WRITE && region.kind == RegionType::READ {
+            return Err(MemorySafetyError::new(&format!("Access does not match region type {:#?} {:?} {:?}", region.kind, ty, base_expr)));
         }
 
         let mut abs_offset = ast::Int::from_i64(self.context, offset);

--- a/memsafe-checker/src/engine.rs
+++ b/memsafe-checker/src/engine.rs
@@ -166,8 +166,7 @@ impl<'ctx> ExecutionEngine<'ctx> {
 
     pub fn add_abstract_expression_from(&mut self, register: usize, value: AbstractExpression) {
         let name = ("x".to_owned() + &register.to_string()).to_string();
-        self.computer
-            .set_abstract(name.clone(),value);
+        self.computer.set_abstract(name.clone(), value);
     }
 
     pub fn add_abstract_from(&mut self, register: usize, value: String) {

--- a/memsafe-checker/src/engine.rs
+++ b/memsafe-checker/src/engine.rs
@@ -164,6 +164,12 @@ impl<'ctx> ExecutionEngine<'ctx> {
         self.computer.set_abstract(register, value);
     }
 
+    pub fn add_abstract_expression_from(&mut self, register: usize, value: AbstractExpression) {
+        let name = ("x".to_owned() + &register.to_string()).to_string();
+        self.computer
+            .set_abstract(name.clone(),value);
+    }
+
     pub fn add_abstract_from(&mut self, register: usize, value: String) {
         let name = ("x".to_owned() + &register.to_string()).to_string();
         self.computer

--- a/memsafe-checker/tests/asm-examples/abstract-loop.S
+++ b/memsafe-checker/tests/asm-examples/abstract-loop.S
@@ -2,7 +2,7 @@ start:
     add x3,x1,x2
 loop:
     ldr x4,[x1]
-    add x1,x1,#1
+    add x1,x1,#4
     cmp x1,x3
     b.ne loop
 add x4,x4,#4

--- a/memsafe-checker/tests/asm-examples/wrapped-ghash-neon-armv8.S
+++ b/memsafe-checker/tests/asm-examples/wrapped-ghash-neon-armv8.S
@@ -61,7 +61,7 @@ _gcm_gmult_neon:
 _gcm_ghash_neon:
 	// AARCH64_VALID_CALL_TARGET
 	cmp x3, xzr
-	b.ne Early_abort
+	b.eq Early_abort
 
 	ld1	{v0.16b}, [x0]		// load Xi
 	ld1	{v5.1d}, [x1], #8		// load twisted H

--- a/memsafe-checker/tests/asm-examples/wrapped-ghash-neon-armv8.S
+++ b/memsafe-checker/tests/asm-examples/wrapped-ghash-neon-armv8.S
@@ -1,0 +1,340 @@
+// This file is generated from a similarly-named Perl script in the BoringSSL
+// source tree. Do not edit by hand.
+
+// #include <openssl/asm_base.h>
+
+// #if !defined(OPENSSL_NO_ASM) && defined(OPENSSL_AARCH64) && defined(__APPLE__)
+// #include <openssl/arm_arch.h>
+
+.text
+
+.globl	_gcm_init_neon
+.private_extern	_gcm_init_neon
+
+.align	4
+_gcm_init_neon:
+	// AARCH64_VALID_CALL_TARGET
+	// This function is adapted from gcm_init_v8. xC2 is t3.
+	ld1	{v17.2d}, [x1]			// load H
+	movi	v19.16b, #0xe1
+	shl	v19.2d, v19.2d, #57		// 0xc2.0
+	ext	v3.16b, v17.16b, v17.16b, #8
+	ushr	v18.2d, v19.2d, #63
+	dup	v17.4s, v17.s[1]
+	ext	v16.16b, v18.16b, v19.16b, #8	// t0=0xc2....01
+	ushr	v18.2d, v3.2d, #63
+	sshr	v17.4s, v17.4s, #31		// broadcast carry bit
+	and	v18.16b, v18.16b, v16.16b
+	shl	v3.2d, v3.2d, #1
+	ext	v18.16b, v18.16b, v18.16b, #8
+	and	v16.16b, v16.16b, v17.16b
+	orr	v3.16b, v3.16b, v18.16b	// H<<<=1
+	eor	v5.16b, v3.16b, v16.16b	// twisted H
+	st1	{v5.2d}, [x0]			// store Htable[0]
+	ret
+
+
+.globl	_gcm_gmult_neon
+.private_extern	_gcm_gmult_neon
+
+.align	4
+_gcm_gmult_neon:
+	// AARCH64_VALID_CALL_TARGET
+	ld1	{v3.16b}, [x0]		// load Xi
+	ld1	{v5.1d}, [x1], #8		// load twisted H
+	ld1	{v6.1d}, [x1]
+	adrp	x9, Lmasks@PAGE		// load constants
+	add	x9, x9, Lmasks@PAGEOFF
+	ld1	{v24.2d, v25.2d}, [x9]
+	rev64	v3.16b, v3.16b		// byteswap Xi
+	ext	v3.16b, v3.16b, v3.16b, #8
+	eor	v7.8b, v5.8b, v6.8b	// Karatsuba pre-processing
+
+	mov	x3, #16
+	b	Lgmult_neon
+
+
+.globl	_gcm_ghash_neon
+.private_extern	_gcm_ghash_neon
+
+.align	4
+_gcm_ghash_neon:
+	// AARCH64_VALID_CALL_TARGET
+	cmp x3, xzr
+	b.ne Early_abort
+
+	ld1	{v0.16b}, [x0]		// load Xi
+	ld1	{v5.1d}, [x1], #8		// load twisted H
+	ld1	{v6.1d}, [x1]
+	adrp	x9, Lmasks@PAGE		// load constants
+	add	x9, x9, Lmasks@PAGEOFF
+	ld1	{v24.2d, v25.2d}, [x9]
+	rev64	v0.16b, v0.16b		// byteswap Xi
+	ext	v0.16b, v0.16b, v0.16b, #8
+	eor	v7.8b, v5.8b, v6.8b	// Karatsuba pre-processing
+
+Loop_neon:
+	ld1	{v3.16b}, [x2], #16	// load inp
+	rev64	v3.16b, v3.16b		// byteswap inp
+	ext	v3.16b, v3.16b, v3.16b, #8
+	eor	v3.16b, v3.16b, v0.16b	// inp ^= Xi
+
+Lgmult_neon:
+	// Split the input into v3 and v4. (The upper halves are unused,
+	// so it is okay to leave them alone.)
+	ins	v4.d[0], v3.d[1]
+	ext	v16.8b, v5.8b, v5.8b, #1	// A1
+	pmull	v16.8h, v16.8b, v3.8b		// F = A1*B
+	ext	v0.8b, v3.8b, v3.8b, #1		// B1
+	pmull	v0.8h, v5.8b, v0.8b		// E = A*B1
+	ext	v17.8b, v5.8b, v5.8b, #2	// A2
+	pmull	v17.8h, v17.8b, v3.8b		// H = A2*B
+	ext	v19.8b, v3.8b, v3.8b, #2	// B2
+	pmull	v19.8h, v5.8b, v19.8b		// G = A*B2
+	ext	v18.8b, v5.8b, v5.8b, #3	// A3
+	eor	v16.16b, v16.16b, v0.16b	// L = E + F
+	pmull	v18.8h, v18.8b, v3.8b		// J = A3*B
+	ext	v0.8b, v3.8b, v3.8b, #3		// B3
+	eor	v17.16b, v17.16b, v19.16b	// M = G + H
+	pmull	v0.8h, v5.8b, v0.8b		// I = A*B3
+
+	// Here we diverge from the 32-bit version. It computes the following
+	// (instructions reordered for clarity):
+	//
+	//     veor	$t0#lo, $t0#lo, $t0#hi	@ t0 = P0 + P1 (L)
+	//     vand	$t0#hi, $t0#hi, $k48
+	//     veor	$t0#lo, $t0#lo, $t0#hi
+	//
+	//     veor	$t1#lo, $t1#lo, $t1#hi	@ t1 = P2 + P3 (M)
+	//     vand	$t1#hi, $t1#hi, $k32
+	//     veor	$t1#lo, $t1#lo, $t1#hi
+	//
+	//     veor	$t2#lo, $t2#lo, $t2#hi	@ t2 = P4 + P5 (N)
+	//     vand	$t2#hi, $t2#hi, $k16
+	//     veor	$t2#lo, $t2#lo, $t2#hi
+	//
+	//     veor	$t3#lo, $t3#lo, $t3#hi	@ t3 = P6 + P7 (K)
+	//     vmov.i64	$t3#hi, #0
+	//
+	// $kN is a mask with the bottom N bits set. AArch64 cannot compute on
+	// upper halves of SIMD registers, so we must split each half into
+	// separate registers. To compensate, we pair computations up and
+	// parallelize.
+
+	ext	v19.8b, v3.8b, v3.8b, #4	// B4
+	eor	v18.16b, v18.16b, v0.16b	// N = I + J
+	pmull	v19.8h, v5.8b, v19.8b		// K = A*B4
+
+	// This can probably be scheduled more efficiently. For now, we just
+	// pair up independent instructions.
+	zip1	v20.2d, v16.2d, v17.2d
+	zip1	v22.2d, v18.2d, v19.2d
+	zip2	v21.2d, v16.2d, v17.2d
+	zip2	v23.2d, v18.2d, v19.2d
+	eor	v20.16b, v20.16b, v21.16b
+	eor	v22.16b, v22.16b, v23.16b
+	and	v21.16b, v21.16b, v24.16b
+	and	v23.16b, v23.16b, v25.16b
+	eor	v20.16b, v20.16b, v21.16b
+	eor	v22.16b, v22.16b, v23.16b
+	zip1	v16.2d, v20.2d, v21.2d
+	zip1	v18.2d, v22.2d, v23.2d
+	zip2	v17.2d, v20.2d, v21.2d
+	zip2	v19.2d, v22.2d, v23.2d
+
+	ext	v16.16b, v16.16b, v16.16b, #15	// t0 = t0 << 8
+	ext	v17.16b, v17.16b, v17.16b, #14	// t1 = t1 << 16
+	pmull	v0.8h, v5.8b, v3.8b		// D = A*B
+	ext	v19.16b, v19.16b, v19.16b, #12	// t3 = t3 << 32
+	ext	v18.16b, v18.16b, v18.16b, #13	// t2 = t2 << 24
+	eor	v16.16b, v16.16b, v17.16b
+	eor	v18.16b, v18.16b, v19.16b
+	eor	v0.16b, v0.16b, v16.16b
+	eor	v0.16b, v0.16b, v18.16b
+	eor	v3.8b, v3.8b, v4.8b	// Karatsuba pre-processing
+	ext	v16.8b, v7.8b, v7.8b, #1	// A1
+	pmull	v16.8h, v16.8b, v3.8b		// F = A1*B
+	ext	v1.8b, v3.8b, v3.8b, #1		// B1
+	pmull	v1.8h, v7.8b, v1.8b		// E = A*B1
+	ext	v17.8b, v7.8b, v7.8b, #2	// A2
+	pmull	v17.8h, v17.8b, v3.8b		// H = A2*B
+	ext	v19.8b, v3.8b, v3.8b, #2	// B2
+	pmull	v19.8h, v7.8b, v19.8b		// G = A*B2
+	ext	v18.8b, v7.8b, v7.8b, #3	// A3
+	eor	v16.16b, v16.16b, v1.16b	// L = E + F
+	pmull	v18.8h, v18.8b, v3.8b		// J = A3*B
+	ext	v1.8b, v3.8b, v3.8b, #3		// B3
+	eor	v17.16b, v17.16b, v19.16b	// M = G + H
+	pmull	v1.8h, v7.8b, v1.8b		// I = A*B3
+
+	// Here we diverge from the 32-bit version. It computes the following
+	// (instructions reordered for clarity):
+	//
+	//     veor	$t0#lo, $t0#lo, $t0#hi	@ t0 = P0 + P1 (L)
+	//     vand	$t0#hi, $t0#hi, $k48
+	//     veor	$t0#lo, $t0#lo, $t0#hi
+	//
+	//     veor	$t1#lo, $t1#lo, $t1#hi	@ t1 = P2 + P3 (M)
+	//     vand	$t1#hi, $t1#hi, $k32
+	//     veor	$t1#lo, $t1#lo, $t1#hi
+	//
+	//     veor	$t2#lo, $t2#lo, $t2#hi	@ t2 = P4 + P5 (N)
+	//     vand	$t2#hi, $t2#hi, $k16
+	//     veor	$t2#lo, $t2#lo, $t2#hi
+	//
+	//     veor	$t3#lo, $t3#lo, $t3#hi	@ t3 = P6 + P7 (K)
+	//     vmov.i64	$t3#hi, #0
+	//
+	// $kN is a mask with the bottom N bits set. AArch64 cannot compute on
+	// upper halves of SIMD registers, so we must split each half into
+	// separate registers. To compensate, we pair computations up and
+	// parallelize.
+
+	ext	v19.8b, v3.8b, v3.8b, #4	// B4
+	eor	v18.16b, v18.16b, v1.16b	// N = I + J
+	pmull	v19.8h, v7.8b, v19.8b		// K = A*B4
+
+	// This can probably be scheduled more efficiently. For now, we just
+	// pair up independent instructions.
+	zip1	v20.2d, v16.2d, v17.2d
+	zip1	v22.2d, v18.2d, v19.2d
+	zip2	v21.2d, v16.2d, v17.2d
+	zip2	v23.2d, v18.2d, v19.2d
+	eor	v20.16b, v20.16b, v21.16b
+	eor	v22.16b, v22.16b, v23.16b
+	and	v21.16b, v21.16b, v24.16b
+	and	v23.16b, v23.16b, v25.16b
+	eor	v20.16b, v20.16b, v21.16b
+	eor	v22.16b, v22.16b, v23.16b
+	zip1	v16.2d, v20.2d, v21.2d
+	zip1	v18.2d, v22.2d, v23.2d
+	zip2	v17.2d, v20.2d, v21.2d
+	zip2	v19.2d, v22.2d, v23.2d
+
+	ext	v16.16b, v16.16b, v16.16b, #15	// t0 = t0 << 8
+	ext	v17.16b, v17.16b, v17.16b, #14	// t1 = t1 << 16
+	pmull	v1.8h, v7.8b, v3.8b		// D = A*B
+	ext	v19.16b, v19.16b, v19.16b, #12	// t3 = t3 << 32
+	ext	v18.16b, v18.16b, v18.16b, #13	// t2 = t2 << 24
+	eor	v16.16b, v16.16b, v17.16b
+	eor	v18.16b, v18.16b, v19.16b
+	eor	v1.16b, v1.16b, v16.16b
+	eor	v1.16b, v1.16b, v18.16b
+	ext	v16.8b, v6.8b, v6.8b, #1	// A1
+	pmull	v16.8h, v16.8b, v4.8b		// F = A1*B
+	ext	v2.8b, v4.8b, v4.8b, #1		// B1
+	pmull	v2.8h, v6.8b, v2.8b		// E = A*B1
+	ext	v17.8b, v6.8b, v6.8b, #2	// A2
+	pmull	v17.8h, v17.8b, v4.8b		// H = A2*B
+	ext	v19.8b, v4.8b, v4.8b, #2	// B2
+	pmull	v19.8h, v6.8b, v19.8b		// G = A*B2
+	ext	v18.8b, v6.8b, v6.8b, #3	// A3
+	eor	v16.16b, v16.16b, v2.16b	// L = E + F
+	pmull	v18.8h, v18.8b, v4.8b		// J = A3*B
+	ext	v2.8b, v4.8b, v4.8b, #3		// B3
+	eor	v17.16b, v17.16b, v19.16b	// M = G + H
+	pmull	v2.8h, v6.8b, v2.8b		// I = A*B3
+
+	// Here we diverge from the 32-bit version. It computes the following
+	// (instructions reordered for clarity):
+	//
+	//     veor	$t0#lo, $t0#lo, $t0#hi	@ t0 = P0 + P1 (L)
+	//     vand	$t0#hi, $t0#hi, $k48
+	//     veor	$t0#lo, $t0#lo, $t0#hi
+	//
+	//     veor	$t1#lo, $t1#lo, $t1#hi	@ t1 = P2 + P3 (M)
+	//     vand	$t1#hi, $t1#hi, $k32
+	//     veor	$t1#lo, $t1#lo, $t1#hi
+	//
+	//     veor	$t2#lo, $t2#lo, $t2#hi	@ t2 = P4 + P5 (N)
+	//     vand	$t2#hi, $t2#hi, $k16
+	//     veor	$t2#lo, $t2#lo, $t2#hi
+	//
+	//     veor	$t3#lo, $t3#lo, $t3#hi	@ t3 = P6 + P7 (K)
+	//     vmov.i64	$t3#hi, #0
+	//
+	// $kN is a mask with the bottom N bits set. AArch64 cannot compute on
+	// upper halves of SIMD registers, so we must split each half into
+	// separate registers. To compensate, we pair computations up and
+	// parallelize.
+
+	ext	v19.8b, v4.8b, v4.8b, #4	// B4
+	eor	v18.16b, v18.16b, v2.16b	// N = I + J
+	pmull	v19.8h, v6.8b, v19.8b		// K = A*B4
+
+	// This can probably be scheduled more efficiently. For now, we just
+	// pair up independent instructions.
+	zip1	v20.2d, v16.2d, v17.2d
+	zip1	v22.2d, v18.2d, v19.2d
+	zip2	v21.2d, v16.2d, v17.2d
+	zip2	v23.2d, v18.2d, v19.2d
+	eor	v20.16b, v20.16b, v21.16b
+	eor	v22.16b, v22.16b, v23.16b
+	and	v21.16b, v21.16b, v24.16b
+	and	v23.16b, v23.16b, v25.16b
+	eor	v20.16b, v20.16b, v21.16b
+	eor	v22.16b, v22.16b, v23.16b
+	zip1	v16.2d, v20.2d, v21.2d
+	zip1	v18.2d, v22.2d, v23.2d
+	zip2	v17.2d, v20.2d, v21.2d
+	zip2	v19.2d, v22.2d, v23.2d
+
+	ext	v16.16b, v16.16b, v16.16b, #15	// t0 = t0 << 8
+	ext	v17.16b, v17.16b, v17.16b, #14	// t1 = t1 << 16
+	pmull	v2.8h, v6.8b, v4.8b		// D = A*B
+	ext	v19.16b, v19.16b, v19.16b, #12	// t3 = t3 << 32
+	ext	v18.16b, v18.16b, v18.16b, #13	// t2 = t2 << 24
+	eor	v16.16b, v16.16b, v17.16b
+	eor	v18.16b, v18.16b, v19.16b
+	eor	v2.16b, v2.16b, v16.16b
+	eor	v2.16b, v2.16b, v18.16b
+	ext	v16.16b, v0.16b, v2.16b, #8
+	eor	v1.16b, v1.16b, v0.16b	// Karatsuba post-processing
+	eor	v1.16b, v1.16b, v2.16b
+	eor	v1.16b, v1.16b, v16.16b	// Xm overlaps Xh.lo and Xl.hi
+	ins	v0.d[1], v1.d[0]		// Xh|Xl - 256-bit result
+	// This is a no-op due to the ins instruction below.
+	// ins	v2.d[0], v1.d[1]
+
+	// equivalent of reduction_avx from ghash-x86_64.pl
+	shl	v17.2d, v0.2d, #57		// 1st phase
+	shl	v18.2d, v0.2d, #62
+	eor	v18.16b, v18.16b, v17.16b	//
+	shl	v17.2d, v0.2d, #63
+	eor	v18.16b, v18.16b, v17.16b	//
+	// Note Xm contains {Xl.d[1], Xh.d[0]}.
+	eor	v18.16b, v18.16b, v1.16b
+	ins	v0.d[1], v18.d[0]		// Xl.d[1] ^= t2.d[0]
+	ins	v2.d[0], v18.d[1]		// Xh.d[0] ^= t2.d[1]
+
+	ushr	v18.2d, v0.2d, #1		// 2nd phase
+	eor	v2.16b, v2.16b,v0.16b
+	eor	v0.16b, v0.16b,v18.16b	//
+	ushr	v18.2d, v18.2d, #6
+	ushr	v0.2d, v0.2d, #1		//
+	eor	v0.16b, v0.16b, v2.16b	//
+	eor	v0.16b, v0.16b, v18.16b	//
+
+	subs	x3, x3, #16
+	bne	Loop_neon
+
+	rev64	v0.16b, v0.16b		// byteswap Xi and write
+	ext	v0.16b, v0.16b, v0.16b, #8
+	st1	{v0.16b}, [x0]
+
+	ret
+
+Early_abort:
+	ret
+
+.section	__TEXT,__const
+.align	4
+Lmasks:
+.quad	0x0000ffffffffffff	// k48
+.quad	0x00000000ffffffff	// k32
+.quad	0x000000000000ffff	// k16
+.quad	0x0000000000000000	// k0
+.byte	71,72,65,83,72,32,102,111,114,32,65,82,77,118,56,44,32,100,101,114,105,118,101,100,32,102,114,111,109,32,65,82,77,118,52,32,118,101,114,115,105,111,110,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
+.align	2
+.align	2
+// #endif  // !OPENSSL_NO_ASM && defined(OPENSSL_AARCH64) && defined(__APPLE__)

--- a/memsafe-checker/tests/asm-examples/wrapped-sha256-armv8-ios64.S
+++ b/memsafe-checker/tests/asm-examples/wrapped-sha256-armv8-ios64.S
@@ -1,0 +1,953 @@
+.text
+
+.private_extern	_OPENSSL_armcap_P
+.globl	_sha256_block_data_order
+.private_extern	_sha256_block_data_order
+
+.align	6
+_sha256_block_data_order:
+	cmp x2, xzr
+	b.eq Early_abort
+	
+	stp	x29,x30,[sp,#-128]!
+	add	x29,sp,#0
+
+	stp	x19,x20,[sp,#16]
+	stp	x21,x22,[sp,#32]
+	stp	x23,x24,[sp,#48]
+	stp	x25,x26,[sp,#64]
+	stp	x27,x28,[sp,#80]
+	sub	sp,sp,#4*4
+
+	ldp	w20,w21,[x0]				// load context
+	ldp	w22,w23,[x0,#2*4]
+	ldp	w24,w25,[x0,#4*4]
+	add	x2,x1,x2,lsl#6	// end of input
+	ldp	w26,w27,[x0,#6*4]
+	adrp	x30,LK256@PAGE
+	add	x30,x30,LK256@PAGEOFF
+	stp	x0,x2,[x29,#96]
+
+Loop:
+	ldp	w3,w4,[x1],#2*4
+	ldr	w19,[x30],#4			// *K++
+	eor	w28,w21,w22				// magic seed
+	str	x1,[x29,#112]
+	ror	w16,w24,#6
+	add	w27,w27,w19			// h+=K[i]
+	eor	w6,w24,w24,ror#14
+	and	w17,w25,w24
+	bic	w19,w26,w24
+	add	w27,w27,w3			// h+=X[i]
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w20,w21			// a^b, b^c in next round
+	eor	w16,w16,w6,ror#11	// Sigma1(e)
+	ror	w6,w20,#2
+	add	w27,w27,w17			// h+=Ch(e,f,g)
+	eor	w17,w20,w20,ror#9
+	add	w27,w27,w16			// h+=Sigma1(e)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	add	w23,w23,w27			// d+=h
+	eor	w28,w28,w21			// Maj(a,b,c)
+	eor	w17,w6,w17,ror#13	// Sigma0(a)
+	add	w27,w27,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	//add	w27,w27,w17			// h+=Sigma0(a)
+	ldp	w5,w6,[x1],#2*4
+	add	w27,w27,w17			// h+=Sigma0(a)
+	ror	w16,w23,#6
+	add	w26,w26,w28			// h+=K[i]
+	eor	w7,w23,w23,ror#14
+	and	w17,w24,w23
+	bic	w28,w25,w23
+	add	w26,w26,w4			// h+=X[i]
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w27,w20			// a^b, b^c in next round
+	eor	w16,w16,w7,ror#11	// Sigma1(e)
+	ror	w7,w27,#2
+	add	w26,w26,w17			// h+=Ch(e,f,g)
+	eor	w17,w27,w27,ror#9
+	add	w26,w26,w16			// h+=Sigma1(e)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	add	w22,w22,w26			// d+=h
+	eor	w19,w19,w20			// Maj(a,b,c)
+	eor	w17,w7,w17,ror#13	// Sigma0(a)
+	add	w26,w26,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	//add	w26,w26,w17			// h+=Sigma0(a)
+	add	w26,w26,w17			// h+=Sigma0(a)
+	ror	w16,w22,#6
+	add	w25,w25,w19			// h+=K[i]
+	eor	w8,w22,w22,ror#14
+	and	w17,w23,w22
+	bic	w19,w24,w22
+	add	w25,w25,w5			// h+=X[i]
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w26,w27			// a^b, b^c in next round
+	eor	w16,w16,w8,ror#11	// Sigma1(e)
+	ror	w8,w26,#2
+	add	w25,w25,w17			// h+=Ch(e,f,g)
+	eor	w17,w26,w26,ror#9
+	add	w25,w25,w16			// h+=Sigma1(e)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	add	w21,w21,w25			// d+=h
+	eor	w28,w28,w27			// Maj(a,b,c)
+	eor	w17,w8,w17,ror#13	// Sigma0(a)
+	add	w25,w25,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	//add	w25,w25,w17			// h+=Sigma0(a)
+	ldp	w7,w8,[x1],#2*4
+	add	w25,w25,w17			// h+=Sigma0(a)
+	ror	w16,w21,#6
+	add	w24,w24,w28			// h+=K[i]
+	eor	w9,w21,w21,ror#14
+	and	w17,w22,w21
+	bic	w28,w23,w21
+	add	w24,w24,w6			// h+=X[i]
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w25,w26			// a^b, b^c in next round
+	eor	w16,w16,w9,ror#11	// Sigma1(e)
+	ror	w9,w25,#2
+	add	w24,w24,w17			// h+=Ch(e,f,g)
+	eor	w17,w25,w25,ror#9
+	add	w24,w24,w16			// h+=Sigma1(e)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	add	w20,w20,w24			// d+=h
+	eor	w19,w19,w26			// Maj(a,b,c)
+	eor	w17,w9,w17,ror#13	// Sigma0(a)
+	add	w24,w24,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	//add	w24,w24,w17			// h+=Sigma0(a)
+	add	w24,w24,w17			// h+=Sigma0(a)
+	ror	w16,w20,#6
+	add	w23,w23,w19			// h+=K[i]
+	eor	w10,w20,w20,ror#14
+	and	w17,w21,w20
+	bic	w19,w22,w20
+	add	w23,w23,w7			// h+=X[i]
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w24,w25			// a^b, b^c in next round
+	eor	w16,w16,w10,ror#11	// Sigma1(e)
+	ror	w10,w24,#2
+	add	w23,w23,w17			// h+=Ch(e,f,g)
+	eor	w17,w24,w24,ror#9
+	add	w23,w23,w16			// h+=Sigma1(e)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	add	w27,w27,w23			// d+=h
+	eor	w28,w28,w25			// Maj(a,b,c)
+	eor	w17,w10,w17,ror#13	// Sigma0(a)
+	add	w23,w23,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	//add	w23,w23,w17			// h+=Sigma0(a)
+	ldp	w9,w10,[x1],#2*4
+	add	w23,w23,w17			// h+=Sigma0(a)
+	ror	w16,w27,#6
+	add	w22,w22,w28			// h+=K[i]
+	eor	w11,w27,w27,ror#14
+	and	w17,w20,w27
+	bic	w28,w21,w27
+	add	w22,w22,w8			// h+=X[i]
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w23,w24			// a^b, b^c in next round
+	eor	w16,w16,w11,ror#11	// Sigma1(e)
+	ror	w11,w23,#2
+	add	w22,w22,w17			// h+=Ch(e,f,g)
+	eor	w17,w23,w23,ror#9
+	add	w22,w22,w16			// h+=Sigma1(e)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	add	w26,w26,w22			// d+=h
+	eor	w19,w19,w24			// Maj(a,b,c)
+	eor	w17,w11,w17,ror#13	// Sigma0(a)
+	add	w22,w22,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	//add	w22,w22,w17			// h+=Sigma0(a)
+	add	w22,w22,w17			// h+=Sigma0(a)
+	ror	w16,w26,#6
+	add	w21,w21,w19			// h+=K[i]
+	eor	w12,w26,w26,ror#14
+	and	w17,w27,w26
+	bic	w19,w20,w26
+	add	w21,w21,w9			// h+=X[i]
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w22,w23			// a^b, b^c in next round
+	eor	w16,w16,w12,ror#11	// Sigma1(e)
+	ror	w12,w22,#2
+	add	w21,w21,w17			// h+=Ch(e,f,g)
+	eor	w17,w22,w22,ror#9
+	add	w21,w21,w16			// h+=Sigma1(e)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	add	w25,w25,w21			// d+=h
+	eor	w28,w28,w23			// Maj(a,b,c)
+	eor	w17,w12,w17,ror#13	// Sigma0(a)
+	add	w21,w21,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	//add	w21,w21,w17			// h+=Sigma0(a)
+	ldp	w11,w12,[x1],#2*4
+	add	w21,w21,w17			// h+=Sigma0(a)
+	ror	w16,w25,#6
+	add	w20,w20,w28			// h+=K[i]
+	eor	w13,w25,w25,ror#14
+	and	w17,w26,w25
+	bic	w28,w27,w25
+	add	w20,w20,w10			// h+=X[i]
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w21,w22			// a^b, b^c in next round
+	eor	w16,w16,w13,ror#11	// Sigma1(e)
+	ror	w13,w21,#2
+	add	w20,w20,w17			// h+=Ch(e,f,g)
+	eor	w17,w21,w21,ror#9
+	add	w20,w20,w16			// h+=Sigma1(e)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	add	w24,w24,w20			// d+=h
+	eor	w19,w19,w22			// Maj(a,b,c)
+	eor	w17,w13,w17,ror#13	// Sigma0(a)
+	add	w20,w20,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	//add	w20,w20,w17			// h+=Sigma0(a)
+	add	w20,w20,w17			// h+=Sigma0(a)
+	ror	w16,w24,#6
+	add	w27,w27,w19			// h+=K[i]
+	eor	w14,w24,w24,ror#14
+	and	w17,w25,w24
+	bic	w19,w26,w24
+	add	w27,w27,w11			// h+=X[i]
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w20,w21			// a^b, b^c in next round
+	eor	w16,w16,w14,ror#11	// Sigma1(e)
+	ror	w14,w20,#2
+	add	w27,w27,w17			// h+=Ch(e,f,g)
+	eor	w17,w20,w20,ror#9
+	add	w27,w27,w16			// h+=Sigma1(e)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	add	w23,w23,w27			// d+=h
+	eor	w28,w28,w21			// Maj(a,b,c)
+	eor	w17,w14,w17,ror#13	// Sigma0(a)
+	add	w27,w27,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	//add	w27,w27,w17			// h+=Sigma0(a)
+	ldp	w13,w14,[x1],#2*4
+	add	w27,w27,w17			// h+=Sigma0(a)
+	ror	w16,w23,#6
+	add	w26,w26,w28			// h+=K[i]
+	eor	w15,w23,w23,ror#14
+	and	w17,w24,w23
+	bic	w28,w25,w23
+	add	w26,w26,w12			// h+=X[i]
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w27,w20			// a^b, b^c in next round
+	eor	w16,w16,w15,ror#11	// Sigma1(e)
+	ror	w15,w27,#2
+	add	w26,w26,w17			// h+=Ch(e,f,g)
+	eor	w17,w27,w27,ror#9
+	add	w26,w26,w16			// h+=Sigma1(e)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	add	w22,w22,w26			// d+=h
+	eor	w19,w19,w20			// Maj(a,b,c)
+	eor	w17,w15,w17,ror#13	// Sigma0(a)
+	add	w26,w26,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	//add	w26,w26,w17			// h+=Sigma0(a)
+	add	w26,w26,w17			// h+=Sigma0(a)
+	ror	w16,w22,#6
+	add	w25,w25,w19			// h+=K[i]
+	eor	w0,w22,w22,ror#14
+	and	w17,w23,w22
+	bic	w19,w24,w22
+	add	w25,w25,w13			// h+=X[i]
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w26,w27			// a^b, b^c in next round
+	eor	w16,w16,w0,ror#11	// Sigma1(e)
+	ror	w0,w26,#2
+	add	w25,w25,w17			// h+=Ch(e,f,g)
+	eor	w17,w26,w26,ror#9
+	add	w25,w25,w16			// h+=Sigma1(e)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	add	w21,w21,w25			// d+=h
+	eor	w28,w28,w27			// Maj(a,b,c)
+	eor	w17,w0,w17,ror#13	// Sigma0(a)
+	add	w25,w25,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	//add	w25,w25,w17			// h+=Sigma0(a)
+	ldp	w15,w0,[x1],#2*4
+	add	w25,w25,w17			// h+=Sigma0(a)
+	str	w6,[sp,#12]
+	ror	w16,w21,#6
+	add	w24,w24,w28			// h+=K[i]
+	eor	w6,w21,w21,ror#14
+	and	w17,w22,w21
+	bic	w28,w23,w21
+	add	w24,w24,w14			// h+=X[i]
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w25,w26			// a^b, b^c in next round
+	eor	w16,w16,w6,ror#11	// Sigma1(e)
+	ror	w6,w25,#2
+	add	w24,w24,w17			// h+=Ch(e,f,g)
+	eor	w17,w25,w25,ror#9
+	add	w24,w24,w16			// h+=Sigma1(e)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	add	w20,w20,w24			// d+=h
+	eor	w19,w19,w26			// Maj(a,b,c)
+	eor	w17,w6,w17,ror#13	// Sigma0(a)
+	add	w24,w24,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	//add	w24,w24,w17			// h+=Sigma0(a)
+	add	w24,w24,w17			// h+=Sigma0(a)
+	str	w7,[sp,#0]
+	ror	w16,w20,#6
+	add	w23,w23,w19			// h+=K[i]
+	eor	w7,w20,w20,ror#14
+	and	w17,w21,w20
+	bic	w19,w22,w20
+	add	w23,w23,w15			// h+=X[i]
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w24,w25			// a^b, b^c in next round
+	eor	w16,w16,w7,ror#11	// Sigma1(e)
+	ror	w7,w24,#2
+	add	w23,w23,w17			// h+=Ch(e,f,g)
+	eor	w17,w24,w24,ror#9
+	add	w23,w23,w16			// h+=Sigma1(e)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	add	w27,w27,w23			// d+=h
+	eor	w28,w28,w25			// Maj(a,b,c)
+	eor	w17,w7,w17,ror#13	// Sigma0(a)
+	add	w23,w23,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	//add	w23,w23,w17			// h+=Sigma0(a)
+	ldp	w1,w2,[x1]
+	add	w23,w23,w17			// h+=Sigma0(a)
+	str	w8,[sp,#4]
+	ror	w16,w27,#6
+	add	w22,w22,w28			// h+=K[i]
+	eor	w8,w27,w27,ror#14
+	and	w17,w20,w27
+	bic	w28,w21,w27
+	add	w22,w22,w0			// h+=X[i]
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w23,w24			// a^b, b^c in next round
+	eor	w16,w16,w8,ror#11	// Sigma1(e)
+	ror	w8,w23,#2
+	add	w22,w22,w17			// h+=Ch(e,f,g)
+	eor	w17,w23,w23,ror#9
+	add	w22,w22,w16			// h+=Sigma1(e)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	add	w26,w26,w22			// d+=h
+	eor	w19,w19,w24			// Maj(a,b,c)
+	eor	w17,w8,w17,ror#13	// Sigma0(a)
+	add	w22,w22,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	//add	w22,w22,w17			// h+=Sigma0(a)
+	ldr	w6,[sp,#12]
+	add	w22,w22,w17			// h+=Sigma0(a)
+	str	w9,[sp,#8]
+	ror	w16,w26,#6
+	add	w21,w21,w19			// h+=K[i]
+	eor	w9,w26,w26,ror#14
+	and	w17,w27,w26
+	bic	w19,w20,w26
+	add	w21,w21,w1			// h+=X[i]
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w22,w23			// a^b, b^c in next round
+	eor	w16,w16,w9,ror#11	// Sigma1(e)
+	ror	w9,w22,#2
+	add	w21,w21,w17			// h+=Ch(e,f,g)
+	eor	w17,w22,w22,ror#9
+	add	w21,w21,w16			// h+=Sigma1(e)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	add	w25,w25,w21			// d+=h
+	eor	w28,w28,w23			// Maj(a,b,c)
+	eor	w17,w9,w17,ror#13	// Sigma0(a)
+	add	w21,w21,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	//add	w21,w21,w17			// h+=Sigma0(a)
+	ldr	w7,[sp,#0]
+	add	w21,w21,w17			// h+=Sigma0(a)
+	str	w10,[sp,#12]
+	ror	w16,w25,#6
+	add	w20,w20,w28			// h+=K[i]
+	ror	w9,w4,#7
+	and	w17,w26,w25
+	ror	w8,w1,#17
+	bic	w28,w27,w25
+	ror	w10,w21,#2
+	add	w20,w20,w2			// h+=X[i]
+	eor	w16,w16,w25,ror#11
+	eor	w9,w9,w4,ror#18
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w21,w22			// a^b, b^c in next round
+	eor	w16,w16,w25,ror#25	// Sigma1(e)
+	eor	w10,w10,w21,ror#13
+	add	w20,w20,w17			// h+=Ch(e,f,g)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	eor	w8,w8,w1,ror#19
+	eor	w9,w9,w4,lsr#3	// sigma0(X[i+1])
+	add	w20,w20,w16			// h+=Sigma1(e)
+	eor	w19,w19,w22			// Maj(a,b,c)
+	eor	w17,w10,w21,ror#22	// Sigma0(a)
+	eor	w8,w8,w1,lsr#10	// sigma1(X[i+14])
+	add	w3,w3,w12
+	add	w24,w24,w20			// d+=h
+	add	w20,w20,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	add	w3,w3,w9
+	add	w20,w20,w17			// h+=Sigma0(a)
+	add	w3,w3,w8
+Loop_16_xx:
+	ldr	w8,[sp,#4]
+	str	w11,[sp,#0]
+	ror	w16,w24,#6
+	add	w27,w27,w19			// h+=K[i]
+	ror	w10,w5,#7
+	and	w17,w25,w24
+	ror	w9,w2,#17
+	bic	w19,w26,w24
+	ror	w11,w20,#2
+	add	w27,w27,w3			// h+=X[i]
+	eor	w16,w16,w24,ror#11
+	eor	w10,w10,w5,ror#18
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w20,w21			// a^b, b^c in next round
+	eor	w16,w16,w24,ror#25	// Sigma1(e)
+	eor	w11,w11,w20,ror#13
+	add	w27,w27,w17			// h+=Ch(e,f,g)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	eor	w9,w9,w2,ror#19
+	eor	w10,w10,w5,lsr#3	// sigma0(X[i+1])
+	add	w27,w27,w16			// h+=Sigma1(e)
+	eor	w28,w28,w21			// Maj(a,b,c)
+	eor	w17,w11,w20,ror#22	// Sigma0(a)
+	eor	w9,w9,w2,lsr#10	// sigma1(X[i+14])
+	add	w4,w4,w13
+	add	w23,w23,w27			// d+=h
+	add	w27,w27,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	add	w4,w4,w10
+	add	w27,w27,w17			// h+=Sigma0(a)
+	add	w4,w4,w9
+	ldr	w9,[sp,#8]
+	str	w12,[sp,#4]
+	ror	w16,w23,#6
+	add	w26,w26,w28			// h+=K[i]
+	ror	w11,w6,#7
+	and	w17,w24,w23
+	ror	w10,w3,#17
+	bic	w28,w25,w23
+	ror	w12,w27,#2
+	add	w26,w26,w4			// h+=X[i]
+	eor	w16,w16,w23,ror#11
+	eor	w11,w11,w6,ror#18
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w27,w20			// a^b, b^c in next round
+	eor	w16,w16,w23,ror#25	// Sigma1(e)
+	eor	w12,w12,w27,ror#13
+	add	w26,w26,w17			// h+=Ch(e,f,g)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	eor	w10,w10,w3,ror#19
+	eor	w11,w11,w6,lsr#3	// sigma0(X[i+1])
+	add	w26,w26,w16			// h+=Sigma1(e)
+	eor	w19,w19,w20			// Maj(a,b,c)
+	eor	w17,w12,w27,ror#22	// Sigma0(a)
+	eor	w10,w10,w3,lsr#10	// sigma1(X[i+14])
+	add	w5,w5,w14
+	add	w22,w22,w26			// d+=h
+	add	w26,w26,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	add	w5,w5,w11
+	add	w26,w26,w17			// h+=Sigma0(a)
+	add	w5,w5,w10
+	ldr	w10,[sp,#12]
+	str	w13,[sp,#8]
+	ror	w16,w22,#6
+	add	w25,w25,w19			// h+=K[i]
+	ror	w12,w7,#7
+	and	w17,w23,w22
+	ror	w11,w4,#17
+	bic	w19,w24,w22
+	ror	w13,w26,#2
+	add	w25,w25,w5			// h+=X[i]
+	eor	w16,w16,w22,ror#11
+	eor	w12,w12,w7,ror#18
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w26,w27			// a^b, b^c in next round
+	eor	w16,w16,w22,ror#25	// Sigma1(e)
+	eor	w13,w13,w26,ror#13
+	add	w25,w25,w17			// h+=Ch(e,f,g)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	eor	w11,w11,w4,ror#19
+	eor	w12,w12,w7,lsr#3	// sigma0(X[i+1])
+	add	w25,w25,w16			// h+=Sigma1(e)
+	eor	w28,w28,w27			// Maj(a,b,c)
+	eor	w17,w13,w26,ror#22	// Sigma0(a)
+	eor	w11,w11,w4,lsr#10	// sigma1(X[i+14])
+	add	w6,w6,w15
+	add	w21,w21,w25			// d+=h
+	add	w25,w25,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	add	w6,w6,w12
+	add	w25,w25,w17			// h+=Sigma0(a)
+	add	w6,w6,w11
+	ldr	w11,[sp,#0]
+	str	w14,[sp,#12]
+	ror	w16,w21,#6
+	add	w24,w24,w28			// h+=K[i]
+	ror	w13,w8,#7
+	and	w17,w22,w21
+	ror	w12,w5,#17
+	bic	w28,w23,w21
+	ror	w14,w25,#2
+	add	w24,w24,w6			// h+=X[i]
+	eor	w16,w16,w21,ror#11
+	eor	w13,w13,w8,ror#18
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w25,w26			// a^b, b^c in next round
+	eor	w16,w16,w21,ror#25	// Sigma1(e)
+	eor	w14,w14,w25,ror#13
+	add	w24,w24,w17			// h+=Ch(e,f,g)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	eor	w12,w12,w5,ror#19
+	eor	w13,w13,w8,lsr#3	// sigma0(X[i+1])
+	add	w24,w24,w16			// h+=Sigma1(e)
+	eor	w19,w19,w26			// Maj(a,b,c)
+	eor	w17,w14,w25,ror#22	// Sigma0(a)
+	eor	w12,w12,w5,lsr#10	// sigma1(X[i+14])
+	add	w7,w7,w0
+	add	w20,w20,w24			// d+=h
+	add	w24,w24,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	add	w7,w7,w13
+	add	w24,w24,w17			// h+=Sigma0(a)
+	add	w7,w7,w12
+	ldr	w12,[sp,#4]
+	str	w15,[sp,#0]
+	ror	w16,w20,#6
+	add	w23,w23,w19			// h+=K[i]
+	ror	w14,w9,#7
+	and	w17,w21,w20
+	ror	w13,w6,#17
+	bic	w19,w22,w20
+	ror	w15,w24,#2
+	add	w23,w23,w7			// h+=X[i]
+	eor	w16,w16,w20,ror#11
+	eor	w14,w14,w9,ror#18
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w24,w25			// a^b, b^c in next round
+	eor	w16,w16,w20,ror#25	// Sigma1(e)
+	eor	w15,w15,w24,ror#13
+	add	w23,w23,w17			// h+=Ch(e,f,g)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	eor	w13,w13,w6,ror#19
+	eor	w14,w14,w9,lsr#3	// sigma0(X[i+1])
+	add	w23,w23,w16			// h+=Sigma1(e)
+	eor	w28,w28,w25			// Maj(a,b,c)
+	eor	w17,w15,w24,ror#22	// Sigma0(a)
+	eor	w13,w13,w6,lsr#10	// sigma1(X[i+14])
+	add	w8,w8,w1
+	add	w27,w27,w23			// d+=h
+	add	w23,w23,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	add	w8,w8,w14
+	add	w23,w23,w17			// h+=Sigma0(a)
+	add	w8,w8,w13
+	ldr	w13,[sp,#8]
+	str	w0,[sp,#4]
+	ror	w16,w27,#6
+	add	w22,w22,w28			// h+=K[i]
+	ror	w15,w10,#7
+	and	w17,w20,w27
+	ror	w14,w7,#17
+	bic	w28,w21,w27
+	ror	w0,w23,#2
+	add	w22,w22,w8			// h+=X[i]
+	eor	w16,w16,w27,ror#11
+	eor	w15,w15,w10,ror#18
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w23,w24			// a^b, b^c in next round
+	eor	w16,w16,w27,ror#25	// Sigma1(e)
+	eor	w0,w0,w23,ror#13
+	add	w22,w22,w17			// h+=Ch(e,f,g)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	eor	w14,w14,w7,ror#19
+	eor	w15,w15,w10,lsr#3	// sigma0(X[i+1])
+	add	w22,w22,w16			// h+=Sigma1(e)
+	eor	w19,w19,w24			// Maj(a,b,c)
+	eor	w17,w0,w23,ror#22	// Sigma0(a)
+	eor	w14,w14,w7,lsr#10	// sigma1(X[i+14])
+	add	w9,w9,w2
+	add	w26,w26,w22			// d+=h
+	add	w22,w22,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	add	w9,w9,w15
+	add	w22,w22,w17			// h+=Sigma0(a)
+	add	w9,w9,w14
+	ldr	w14,[sp,#12]
+	str	w1,[sp,#8]
+	ror	w16,w26,#6
+	add	w21,w21,w19			// h+=K[i]
+	ror	w0,w11,#7
+	and	w17,w27,w26
+	ror	w15,w8,#17
+	bic	w19,w20,w26
+	ror	w1,w22,#2
+	add	w21,w21,w9			// h+=X[i]
+	eor	w16,w16,w26,ror#11
+	eor	w0,w0,w11,ror#18
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w22,w23			// a^b, b^c in next round
+	eor	w16,w16,w26,ror#25	// Sigma1(e)
+	eor	w1,w1,w22,ror#13
+	add	w21,w21,w17			// h+=Ch(e,f,g)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	eor	w15,w15,w8,ror#19
+	eor	w0,w0,w11,lsr#3	// sigma0(X[i+1])
+	add	w21,w21,w16			// h+=Sigma1(e)
+	eor	w28,w28,w23			// Maj(a,b,c)
+	eor	w17,w1,w22,ror#22	// Sigma0(a)
+	eor	w15,w15,w8,lsr#10	// sigma1(X[i+14])
+	add	w10,w10,w3
+	add	w25,w25,w21			// d+=h
+	add	w21,w21,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	add	w10,w10,w0
+	add	w21,w21,w17			// h+=Sigma0(a)
+	add	w10,w10,w15
+	ldr	w15,[sp,#0]
+	str	w2,[sp,#12]
+	ror	w16,w25,#6
+	add	w20,w20,w28			// h+=K[i]
+	ror	w1,w12,#7
+	and	w17,w26,w25
+	ror	w0,w9,#17
+	bic	w28,w27,w25
+	ror	w2,w21,#2
+	add	w20,w20,w10			// h+=X[i]
+	eor	w16,w16,w25,ror#11
+	eor	w1,w1,w12,ror#18
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w21,w22			// a^b, b^c in next round
+	eor	w16,w16,w25,ror#25	// Sigma1(e)
+	eor	w2,w2,w21,ror#13
+	add	w20,w20,w17			// h+=Ch(e,f,g)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	eor	w0,w0,w9,ror#19
+	eor	w1,w1,w12,lsr#3	// sigma0(X[i+1])
+	add	w20,w20,w16			// h+=Sigma1(e)
+	eor	w19,w19,w22			// Maj(a,b,c)
+	eor	w17,w2,w21,ror#22	// Sigma0(a)
+	eor	w0,w0,w9,lsr#10	// sigma1(X[i+14])
+	add	w11,w11,w4
+	add	w24,w24,w20			// d+=h
+	add	w20,w20,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	add	w11,w11,w1
+	add	w20,w20,w17			// h+=Sigma0(a)
+	add	w11,w11,w0
+	ldr	w0,[sp,#4]
+	str	w3,[sp,#0]
+	ror	w16,w24,#6
+	add	w27,w27,w19			// h+=K[i]
+	ror	w2,w13,#7
+	and	w17,w25,w24
+	ror	w1,w10,#17
+	bic	w19,w26,w24
+	ror	w3,w20,#2
+	add	w27,w27,w11			// h+=X[i]
+	eor	w16,w16,w24,ror#11
+	eor	w2,w2,w13,ror#18
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w20,w21			// a^b, b^c in next round
+	eor	w16,w16,w24,ror#25	// Sigma1(e)
+	eor	w3,w3,w20,ror#13
+	add	w27,w27,w17			// h+=Ch(e,f,g)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	eor	w1,w1,w10,ror#19
+	eor	w2,w2,w13,lsr#3	// sigma0(X[i+1])
+	add	w27,w27,w16			// h+=Sigma1(e)
+	eor	w28,w28,w21			// Maj(a,b,c)
+	eor	w17,w3,w20,ror#22	// Sigma0(a)
+	eor	w1,w1,w10,lsr#10	// sigma1(X[i+14])
+	add	w12,w12,w5
+	add	w23,w23,w27			// d+=h
+	add	w27,w27,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	add	w12,w12,w2
+	add	w27,w27,w17			// h+=Sigma0(a)
+	add	w12,w12,w1
+	ldr	w1,[sp,#8]
+	str	w4,[sp,#4]
+	ror	w16,w23,#6
+	add	w26,w26,w28			// h+=K[i]
+	ror	w3,w14,#7
+	and	w17,w24,w23
+	ror	w2,w11,#17
+	bic	w28,w25,w23
+	ror	w4,w27,#2
+	add	w26,w26,w12			// h+=X[i]
+	eor	w16,w16,w23,ror#11
+	eor	w3,w3,w14,ror#18
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w27,w20			// a^b, b^c in next round
+	eor	w16,w16,w23,ror#25	// Sigma1(e)
+	eor	w4,w4,w27,ror#13
+	add	w26,w26,w17			// h+=Ch(e,f,g)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	eor	w2,w2,w11,ror#19
+	eor	w3,w3,w14,lsr#3	// sigma0(X[i+1])
+	add	w26,w26,w16			// h+=Sigma1(e)
+	eor	w19,w19,w20			// Maj(a,b,c)
+	eor	w17,w4,w27,ror#22	// Sigma0(a)
+	eor	w2,w2,w11,lsr#10	// sigma1(X[i+14])
+	add	w13,w13,w6
+	add	w22,w22,w26			// d+=h
+	add	w26,w26,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	add	w13,w13,w3
+	add	w26,w26,w17			// h+=Sigma0(a)
+	add	w13,w13,w2
+	ldr	w2,[sp,#12]
+	str	w5,[sp,#8]
+	ror	w16,w22,#6
+	add	w25,w25,w19			// h+=K[i]
+	ror	w4,w15,#7
+	and	w17,w23,w22
+	ror	w3,w12,#17
+	bic	w19,w24,w22
+	ror	w5,w26,#2
+	add	w25,w25,w13			// h+=X[i]
+	eor	w16,w16,w22,ror#11
+	eor	w4,w4,w15,ror#18
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w26,w27			// a^b, b^c in next round
+	eor	w16,w16,w22,ror#25	// Sigma1(e)
+	eor	w5,w5,w26,ror#13
+	add	w25,w25,w17			// h+=Ch(e,f,g)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	eor	w3,w3,w12,ror#19
+	eor	w4,w4,w15,lsr#3	// sigma0(X[i+1])
+	add	w25,w25,w16			// h+=Sigma1(e)
+	eor	w28,w28,w27			// Maj(a,b,c)
+	eor	w17,w5,w26,ror#22	// Sigma0(a)
+	eor	w3,w3,w12,lsr#10	// sigma1(X[i+14])
+	add	w14,w14,w7
+	add	w21,w21,w25			// d+=h
+	add	w25,w25,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	add	w14,w14,w4
+	add	w25,w25,w17			// h+=Sigma0(a)
+	add	w14,w14,w3
+	ldr	w3,[sp,#0]
+	str	w6,[sp,#12]
+	ror	w16,w21,#6
+	add	w24,w24,w28			// h+=K[i]
+	ror	w5,w0,#7
+	and	w17,w22,w21
+	ror	w4,w13,#17
+	bic	w28,w23,w21
+	ror	w6,w25,#2
+	add	w24,w24,w14			// h+=X[i]
+	eor	w16,w16,w21,ror#11
+	eor	w5,w5,w0,ror#18
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w25,w26			// a^b, b^c in next round
+	eor	w16,w16,w21,ror#25	// Sigma1(e)
+	eor	w6,w6,w25,ror#13
+	add	w24,w24,w17			// h+=Ch(e,f,g)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	eor	w4,w4,w13,ror#19
+	eor	w5,w5,w0,lsr#3	// sigma0(X[i+1])
+	add	w24,w24,w16			// h+=Sigma1(e)
+	eor	w19,w19,w26			// Maj(a,b,c)
+	eor	w17,w6,w25,ror#22	// Sigma0(a)
+	eor	w4,w4,w13,lsr#10	// sigma1(X[i+14])
+	add	w15,w15,w8
+	add	w20,w20,w24			// d+=h
+	add	w24,w24,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	add	w15,w15,w5
+	add	w24,w24,w17			// h+=Sigma0(a)
+	add	w15,w15,w4
+	ldr	w4,[sp,#4]
+	str	w7,[sp,#0]
+	ror	w16,w20,#6
+	add	w23,w23,w19			// h+=K[i]
+	ror	w6,w1,#7
+	and	w17,w21,w20
+	ror	w5,w14,#17
+	bic	w19,w22,w20
+	ror	w7,w24,#2
+	add	w23,w23,w15			// h+=X[i]
+	eor	w16,w16,w20,ror#11
+	eor	w6,w6,w1,ror#18
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w24,w25			// a^b, b^c in next round
+	eor	w16,w16,w20,ror#25	// Sigma1(e)
+	eor	w7,w7,w24,ror#13
+	add	w23,w23,w17			// h+=Ch(e,f,g)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	eor	w5,w5,w14,ror#19
+	eor	w6,w6,w1,lsr#3	// sigma0(X[i+1])
+	add	w23,w23,w16			// h+=Sigma1(e)
+	eor	w28,w28,w25			// Maj(a,b,c)
+	eor	w17,w7,w24,ror#22	// Sigma0(a)
+	eor	w5,w5,w14,lsr#10	// sigma1(X[i+14])
+	add	w0,w0,w9
+	add	w27,w27,w23			// d+=h
+	add	w23,w23,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	add	w0,w0,w6
+	add	w23,w23,w17			// h+=Sigma0(a)
+	add	w0,w0,w5
+	ldr	w5,[sp,#8]
+	str	w8,[sp,#4]
+	ror	w16,w27,#6
+	add	w22,w22,w28			// h+=K[i]
+	ror	w7,w2,#7
+	and	w17,w20,w27
+	ror	w6,w15,#17
+	bic	w28,w21,w27
+	ror	w8,w23,#2
+	add	w22,w22,w0			// h+=X[i]
+	eor	w16,w16,w27,ror#11
+	eor	w7,w7,w2,ror#18
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w23,w24			// a^b, b^c in next round
+	eor	w16,w16,w27,ror#25	// Sigma1(e)
+	eor	w8,w8,w23,ror#13
+	add	w22,w22,w17			// h+=Ch(e,f,g)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	eor	w6,w6,w15,ror#19
+	eor	w7,w7,w2,lsr#3	// sigma0(X[i+1])
+	add	w22,w22,w16			// h+=Sigma1(e)
+	eor	w19,w19,w24			// Maj(a,b,c)
+	eor	w17,w8,w23,ror#22	// Sigma0(a)
+	eor	w6,w6,w15,lsr#10	// sigma1(X[i+14])
+	add	w1,w1,w10
+	add	w26,w26,w22			// d+=h
+	add	w22,w22,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	add	w1,w1,w7
+	add	w22,w22,w17			// h+=Sigma0(a)
+	add	w1,w1,w6
+	ldr	w6,[sp,#12]
+	str	w9,[sp,#8]
+	ror	w16,w26,#6
+	add	w21,w21,w19			// h+=K[i]
+	ror	w8,w3,#7
+	and	w17,w27,w26
+	ror	w7,w0,#17
+	bic	w19,w20,w26
+	ror	w9,w22,#2
+	add	w21,w21,w1			// h+=X[i]
+	eor	w16,w16,w26,ror#11
+	eor	w8,w8,w3,ror#18
+	orr	w17,w17,w19			// Ch(e,f,g)
+	eor	w19,w22,w23			// a^b, b^c in next round
+	eor	w16,w16,w26,ror#25	// Sigma1(e)
+	eor	w9,w9,w22,ror#13
+	add	w21,w21,w17			// h+=Ch(e,f,g)
+	and	w28,w28,w19			// (b^c)&=(a^b)
+	eor	w7,w7,w0,ror#19
+	eor	w8,w8,w3,lsr#3	// sigma0(X[i+1])
+	add	w21,w21,w16			// h+=Sigma1(e)
+	eor	w28,w28,w23			// Maj(a,b,c)
+	eor	w17,w9,w22,ror#22	// Sigma0(a)
+	eor	w7,w7,w0,lsr#10	// sigma1(X[i+14])
+	add	w2,w2,w11
+	add	w25,w25,w21			// d+=h
+	add	w21,w21,w28			// h+=Maj(a,b,c)
+	ldr	w28,[x30],#4		// *K++, w19 in next round
+	add	w2,w2,w8
+	add	w21,w21,w17			// h+=Sigma0(a)
+	add	w2,w2,w7
+	ldr	w7,[sp,#0]
+	str	w10,[sp,#12]
+	ror	w16,w25,#6
+	add	w20,w20,w28			// h+=K[i]
+	ror	w9,w4,#7
+	and	w17,w26,w25
+	ror	w8,w1,#17
+	bic	w28,w27,w25
+	ror	w10,w21,#2
+	add	w20,w20,w2			// h+=X[i]
+	eor	w16,w16,w25,ror#11
+	eor	w9,w9,w4,ror#18
+	orr	w17,w17,w28			// Ch(e,f,g)
+	eor	w28,w21,w22			// a^b, b^c in next round
+	eor	w16,w16,w25,ror#25	// Sigma1(e)
+	eor	w10,w10,w21,ror#13
+	add	w20,w20,w17			// h+=Ch(e,f,g)
+	and	w19,w19,w28			// (b^c)&=(a^b)
+	eor	w8,w8,w1,ror#19
+	eor	w9,w9,w4,lsr#3	// sigma0(X[i+1])
+	add	w20,w20,w16			// h+=Sigma1(e)
+	eor	w19,w19,w22			// Maj(a,b,c)
+	eor	w17,w10,w21,ror#22	// Sigma0(a)
+	eor	w8,w8,w1,lsr#10	// sigma1(X[i+14])
+	add	w3,w3,w12
+	add	w24,w24,w20			// d+=h
+	add	w20,w20,w19			// h+=Maj(a,b,c)
+	ldr	w19,[x30],#4		// *K++, w28 in next round
+	add	w3,w3,w9
+	add	w20,w20,w17			// h+=Sigma0(a)
+	add	w3,w3,w8
+	cbnz	w19,Loop_16_xx
+
+	ldp	x0,x2,[x29,#96]
+	ldr	x1,[x29,#112]
+	sub	x30,x30,#260		// rewind
+
+	ldp	w3,w4,[x0]
+	ldp	w5,w6,[x0,#2*4]
+	add	x1,x1,#14*4			// advance input pointer
+	ldp	w7,w8,[x0,#4*4]
+	add	w20,w20,w3
+	ldp	w9,w10,[x0,#6*4]
+	add	w21,w21,w4
+	add	w22,w22,w5
+	add	w23,w23,w6
+	stp	w20,w21,[x0]
+	add	w24,w24,w7
+	add	w25,w25,w8
+	stp	w22,w23,[x0,#2*4]
+	add	w26,w26,w9
+	add	w27,w27,w10
+	cmp	x1,x2
+	stp	w24,w25,[x0,#4*4]
+	stp	w26,w27,[x0,#6*4]
+	b.ne	Loop
+
+	ldp	x19,x20,[x29,#16]
+	add	sp,sp,#4*4
+	ldp	x21,x22,[x29,#32]
+	ldp	x23,x24,[x29,#48]
+	ldp	x25,x26,[x29,#64]
+	ldp	x27,x28,[x29,#80]
+	ldp	x29,x30,[sp],#128
+	AARCH64_VALIDATE_LINK_REGISTER
+	ret
+
+Early_abort:
+	ret
+
+.section	__TEXT,__const
+.align	6
+
+LK256:
+.long	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5
+.long	0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5
+.long	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3
+.long	0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174
+.long	0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc
+.long	0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da
+.long	0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7
+.long	0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967
+.long	0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13
+.long	0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85
+.long	0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3
+.long	0xd192e819,0xd6990624,0xf40e3585,0x106aa070
+.long	0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5
+.long	0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3
+.long	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208
+.long	0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+.long	0	//terminator
+
+.byte	83,72,65,50,53,54,32,98,108,111,99,107,32,116,114,97,110,115,102,111,114,109,32,102,111,114,32,65,82,77,118,56,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
+

--- a/memsafe-checker/tests/examples.rs
+++ b/memsafe-checker/tests/examples.rs
@@ -737,7 +737,7 @@ mod tests {
         engine.add_region(
             RegionType::RW,
             "input".to_string(),
-            generate_expression("*", blocks.clone(), AbstractExpression::Immediate(16 * 8)),
+            generate_expression("*", blocks.clone(), AbstractExpression::Immediate(16)),
         );
 
         engine.add_abstract("x3".to_string(), blocks);
@@ -772,7 +772,7 @@ mod tests {
         engine.add_region(
             RegionType::RW,
             "context".to_string(),
-            AbstractExpression::Immediate(16 * 8),
+            AbstractExpression::Immediate(16),
         );
 
         engine.add_abstract(
@@ -793,10 +793,13 @@ mod tests {
         engine.add_region(
             RegionType::RW,
             "input".to_string(),
-            generate_expression("*", blocks.clone(), AbstractExpression::Immediate(16 * 8)),
+            generate_expression("*", blocks.clone(), AbstractExpression::Immediate(16 * 4)),
         );
 
-        engine.add_abstract("x3".to_string(), blocks);
+        engine.add_abstract(
+            "x3".to_string(),
+            generate_expression("*", blocks.clone(), AbstractExpression::Immediate(16)),
+        );
 
         let res = engine.start(start_label);
         assert!(res.is_ok());

--- a/memsafe-checker/tests/examples.rs
+++ b/memsafe-checker/tests/examples.rs
@@ -420,7 +420,7 @@ mod tests {
         engine.add_region(
             RegionType::READ,
             "base".to_string(),
-            AbstractExpression::Immediate(2),
+            AbstractExpression::Immediate(1),
         );
 
         let res = engine.start("start".to_string());
@@ -828,14 +828,14 @@ mod tests {
         engine.add_region(
             RegionType::RW,
             "x0".to_string(),
-            AbstractExpression::Immediate(32),
+            AbstractExpression::Immediate(32 * 8),
         );
 
         let blocks = AbstractExpression::Abstract("Blocks".to_string());
         let length = AbstractExpression::Expression(
-            "lsl".to_string(),
+            "*".to_string(),
             Box::new(blocks.clone()),
-            Box::new(AbstractExpression::Immediate(12)),
+            Box::new(AbstractExpression::Immediate(64 * 8)),
         );
         let base = AbstractExpression::Abstract("Base".to_string());
 

--- a/memsafe-checker/tests/examples.rs
+++ b/memsafe-checker/tests/examples.rs
@@ -7,7 +7,7 @@ mod tests {
 
     #[test]
     fn bn_add() -> std::io::Result<()> {
-        env_logger::init();
+        // env_logger::init();
 
         let file = File::open("tests/asm-examples/bn-armv8-apple.S")?;
         let reader = BufReader::new(file);
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn sha256_armv8_ios64() -> std::io::Result<()> {
-        //env_logger::init();
+        // env_logger::init();
 
         let file = File::open("tests/asm-examples/processed-sha256-armv8-ios64.S")?;
         let reader = BufReader::new(file);
@@ -108,7 +108,7 @@ mod tests {
         let length = AbstractExpression::Expression(
             "lsl".to_string(),
             Box::new(blocks.clone()),
-            Box::new(AbstractExpression::Immediate(6)),
+            Box::new(AbstractExpression::Immediate(12)),
         );
         let base = AbstractExpression::Abstract("Base".to_string());
 
@@ -737,13 +737,115 @@ mod tests {
         engine.add_region(
             RegionType::RW,
             "input".to_string(),
-            generate_expression("*", blocks.clone(), AbstractExpression::Immediate(16)),
+            generate_expression("*", blocks.clone(), AbstractExpression::Immediate(16 * 8)),
         );
 
         engine.add_abstract("x3".to_string(), blocks);
 
         let res = engine.start(start_label);
         assert!(res.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn corrected_simd_gcm_ghash_neon() -> std::io::Result<()> {
+        // env_logger::init();
+
+        let file = File::open("tests/asm-examples/wrapped-ghash-neon-armv8.S")?;
+        let reader = BufReader::new(file);
+        let start_label = String::from("_gcm_ghash_neon");
+
+        let mut program = Vec::new();
+        for line in reader.lines() {
+            program.push(line.unwrap_or(String::from("")));
+        }
+
+        let mut cfg = Config::new();
+        cfg.set_proof_generation(true);
+        let ctx = Context::new(&cfg);
+        let mut engine = bums::engine::ExecutionEngine::new(program, &ctx);
+
+        engine.add_abstract(
+            "x0".to_string(),
+            AbstractExpression::Abstract("context".to_string()),
+        );
+        engine.add_region(
+            RegionType::RW,
+            "context".to_string(),
+            AbstractExpression::Immediate(16 * 8),
+        );
+
+        engine.add_abstract(
+            "x1".to_string(),
+            AbstractExpression::Abstract("h".to_string()),
+        );
+        engine.add_region(
+            RegionType::RW,
+            "h".to_string(),
+            AbstractExpression::Immediate(128 * 16),
+        );
+
+        let blocks = AbstractExpression::Abstract("blocks".to_string());
+        engine.add_abstract(
+            "x2".to_string(),
+            AbstractExpression::Abstract("input".to_string()),
+        );
+        engine.add_region(
+            RegionType::RW,
+            "input".to_string(),
+            generate_expression("*", blocks.clone(), AbstractExpression::Immediate(16 * 8)),
+        );
+
+        engine.add_abstract("x3".to_string(), blocks);
+
+        let res = engine.start(start_label);
+        assert!(res.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn corrected_sha256_armv8_ios64() -> std::io::Result<()> {
+        // env_logger::init();
+
+        let file = File::open("tests/asm-examples/wrapped-sha256-armv8-ios64.S")?;
+        let reader = BufReader::new(file);
+        let start_label = String::from("_sha256_block_data_order");
+
+        let mut program = Vec::new();
+        for line in reader.lines() {
+            program.push(line.unwrap_or(String::from("")));
+        }
+
+        let mut cfg = Config::new();
+        cfg.set_proof_generation(true);
+        let ctx = Context::new(&cfg);
+        let mut engine = bums::engine::ExecutionEngine::new(program, &ctx);
+
+        // x0 -- context
+        engine.add_region(
+            RegionType::RW,
+            "x0".to_string(),
+            AbstractExpression::Immediate(32),
+        );
+
+        let blocks = AbstractExpression::Abstract("Blocks".to_string());
+        let length = AbstractExpression::Expression(
+            "lsl".to_string(),
+            Box::new(blocks.clone()),
+            Box::new(AbstractExpression::Immediate(12)),
+        );
+        let base = AbstractExpression::Abstract("Base".to_string());
+
+        // x1 -- input blocks
+        engine.add_abstract(String::from("x1"), base.clone());
+        engine.add_region(RegionType::READ, "Base".to_string(), length);
+
+        // x2 -- number of blocks
+        engine.add_abstract(String::from("x2"), blocks);
+
+        //engine.dont_fail_fast();
+        let res = engine.start(start_label);
+        assert!(res.is_ok());
         Ok(())
     }
 }


### PR DESCRIPTION
- Add early exit paths in the assembly in case length is zero
- Corrected sha256 and ghash now build in release mode, bn does not
- Change/fix bugs in macro and symbex:
    - Allow negative steps when resolving loops (in ghash, take length =-16 at every loop iteration)
    - Properly transform expressions in Rust into abstract expressions, for example, "buf.len()/16" is transformed to Expression("/", Abstract(buf_len), Immediate(16)).
    - Allow both read and write operations into RW regions
    - fixed a bug around the fact the LENGTH OF A REGION IS REPRESENTED IN BITS
    - formatting nits
   
Notes:
For now, I took out tracking simd register changes across loop iterations because it introduced stack overflows. We need to figure out how to represent the state in a more condensed form.
